### PR TITLE
Support for empty elements without None param

### DIFF
--- a/tests/expected/content_with_child.xml
+++ b/tests/expected/content_with_child.xml
@@ -1,0 +1,3 @@
+<div>Content
+  <img src="http://server/image.jpg" />
+</div>

--- a/tests/expected/empty_node.xml
+++ b/tests/expected/empty_node.xml
@@ -1,0 +1,3 @@
+<div>
+  <img src="http://server/image.jpg" />
+</div>

--- a/tests/xmlwitch_tests.py
+++ b/tests/xmlwitch_tests.py
@@ -112,5 +112,39 @@ class XMLWitchTestCase(unittest.TestCase):
             self.expected_document('atom_feed.xml')
         )
 
+    def test_empty_node_call_as_with_doesnt_double_render(self):
+        # __call__ and __enter__ previously produced two renders:
+        #   <div />                     <--- __call__ invoked
+        #   <div> <img ...> </div>      <--- __enter__ invoked
+        #
+        # __call__ and __enter__ should work together.
+
+        xml = xmlwitch.Builder()
+        with xml.div(None):
+            xml.img(None, src="http://server/image.jpg")
+        self.assertEquals(
+            str(xml),
+            self.expected_document('empty_node.xml')
+        )
+
+    def test_empty_node(self):
+        # Old "None" style
+        xml = xmlwitch.Builder()
+        with xml.div:
+            xml.img(None, src="http://server/image.jpg")
+        self.assertEquals(
+            str(xml),
+            self.expected_document('empty_node.xml')
+        )
+
+        # New empty style
+        xml = xmlwitch.Builder()
+        with xml.div:
+            xml.img(src="http://server/image.jpg")
+        self.assertEquals(
+            str(xml),
+            self.expected_document('empty_node.xml')
+        )
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/xmlwitch_tests.py
+++ b/tests/xmlwitch_tests.py
@@ -127,6 +127,15 @@ class XMLWitchTestCase(unittest.TestCase):
             self.expected_document('empty_node.xml')
         )
 
+    def test_content_with_child(self):
+        xml = xmlwitch.Builder()
+        with xml.div("Content"):
+            xml.img(src="http://server/image.jpg")
+        self.assertEquals(
+            str(xml),
+            self.expected_document('content_with_child.xml')
+        )
+
     def test_empty_node(self):
         # Old "None" style
         xml = xmlwitch.Builder()

--- a/xmlwitch.py
+++ b/xmlwitch.py
@@ -94,7 +94,7 @@ class XmlTreeBuilder:
                         text = "<%s%s>%s</%s>" % (tree[0], tree[1], tree[2], tree[0])
                         builder.write_indented( text )
                     else:
-                        builder.write_indented( "<%s%s>%s", (tree[0], tree[1], tree[2]) )
+                        builder.write_indented( "<%s%s>%s" % (tree[0], tree[1], tree[2]) )
                         builder._indentation += 1
                         self.render_subtree(tree[3], builder)
                         builder._indentation += -1

--- a/xmlwitch.py
+++ b/xmlwitch.py
@@ -21,7 +21,8 @@ class Builder:
             self.write('<?xml version="%s" encoding="%s"?>\n' % (
                 version, encoding
             ))
-    
+        self._treebuilder = XmlTreeBuilder()
+
     def __getattr__(self, name):
         return Element(name, self)
         
@@ -29,11 +30,13 @@ class Builder:
         return Element(name, self)
     
     def __str__(self):
+        self._treebuilder.reset()
+        self._treebuilder.render(self)
         return self._document.getvalue().encode(self._encoding).strip()
         
     def __unicode__(self):
         return self._document.getvalue().decode(self._encoding).strip()
-        
+
     def write(self, content):
         """Write raw content to the document"""
         if type(content) is not unicode:
@@ -50,6 +53,59 @@ class Builder:
 
 builder = Builder # 0.1 backward compatibility
 
+class XmlTreeBuilder:
+
+    def __init__(self):
+        self.root = []
+        self.position = self.root
+        self.stack = []
+        
+    def open_tag(self, tag, attributes, text, with_block=False):
+        if len(self.stack) > 0 and not self.stack[-1][1]:
+            self.position = self.stack.pop()[0]  # pop unclosed
+        self.stack.append([ self.position, with_block ])
+        self.position.append((tag, attributes, text, []))
+        self.position = self.position[-1][3]
+
+    def reopen_tag_with_block(self):
+        self.stack[-1][1] = True
+
+    def close_tag(self):
+        # close last open block
+        while len(self.stack) > 1 and not self.stack[-1][1]:
+            self.position = self.stack.pop()[0]
+
+        self.position = self.stack.pop()[0]
+
+    def reset(self):
+        self.stack = []   # reset stack, effectively closing any remaining open tags
+        self.position = self.root
+
+    def render(self, builder):
+        self.render_subtree(self.root, builder)
+
+    def render_subtree(self, trees, builder):
+        for tree in trees:
+            if tree[2] == None and len(tree[3]) == 0:
+                builder.write_indented( "<%s%s />" % (tree[0], tree[1]) )
+            else:
+                if tree[2] != None:
+                    if len(tree[3]) == 0:
+                        text = "<%s%s>%s</%s>" % (tree[0], tree[1], tree[2], tree[0])
+                        builder.write_indented( text )
+                    else:
+                        builder.write_indented( "<%s%s>%s", (tree[0], tree[1], tree[2]) )
+                        builder._indentation += 1
+                        self.render_subtree(tree[3], builder)
+                        builder._indentation += -1
+                        builder.write_indented( "</%s>" % tree[0] )
+                else:
+                    builder.write_indented( "<%s%s>" % (tree[0], tree[1]) )
+                    builder._indentation += 1
+                    self.render_subtree(tree[3], builder)
+                    builder._indentation += -1
+                    builder.write_indented( "</%s>" % tree[0] )
+
 class Element:
     
     PYTHON_KWORD_MAP = dict([(k + '_', k) for k in PYTHON_KWORD_LIST])
@@ -58,35 +114,36 @@ class Element:
         self.name = self._nameprep(name)
         self.builder = builder
         self.attributes = {}
-        
+        self.opened = False
+        self.tree = builder._treebuilder
+
     def __enter__(self):
         """Add a parent element to the document"""
-        self.builder.write_indented('<%s%s>' % (
-            self.name, self._serialized_attrs()
-        ))
-        self.builder._indentation += 1
+
+        if(self.opened):
+            self.tree.reopen_tag_with_block()
+        else:
+            self.tree.open_tag(self.name, self._serialized_attrs(), None, True)
+            self.opened = True
+
         return self
         
     def __exit__(self, type, value, tb):
         """Add close tag to current parent element"""
-        self.builder._indentation -= 1
-        self.builder.write_indented('</%s>' % self.name)
-        
+        self.tree.close_tag()
+
     def __call__(*args, **kargs):
         """Add a child element to the document"""
         self = args[0]
         self.attributes.update(kargs)
-        if len(args) > 1:
-            value = args[1]
-            if value is None:
-                self.builder.write_indented('<%s%s />' % (
-                    self.name, self._serialized_attrs()
-                ))
-            else:
-                value = saxutils.escape(value)
-                self.builder.write_indented('<%s%s>%s</%s>' % (
-                    self.name, self._serialized_attrs(), value, self.name
-                ))
+
+        value = args[1] if len(args) > 1 else None
+
+        if value:
+            value = saxutils.escape(value)
+
+        self.opened = True
+        self.tree.open_tag(self.name, self._serialized_attrs(), value, False)
         return self
 
     def _serialized_attrs(self):


### PR DESCRIPTION
This change allows both "old style" empty elements, which required a place holder paramater

```
xml.img(None, src="http://server/image.jpg")
```

and "new style", which does not:

```
xml.img(src="http://server/image.jpg")
```

Also, whether to render a close tag in **call** depends on whether this is used in a with context.  To handle this, Builder is reworked to build & modify a tree data structure until **str** is called, at which point the data structure is rendered to text with complete knowledge of the tree.

i.e. the following used to fail, rendering the div twice.  Support for the "new style" made this even more exposed:

```
with xml.div(None, id="name"):
    xml.p("hi")
```
