### PR TITLE
Support both Python 2 + 3, allow stream for large files, unify syntax

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,13 @@
+[run]
+branch = True
+source = xmlwitch.py
+
+[report]
+exclude_lines =
+    if self.debug:
+    pragma: no cover
+    raise NotImplementedError
+    if __name__ == .__main__.:
+ignore_errors = True
+omit =
+    tests/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.pyc
+.idea/
 build/*
 dist/*
 MANIFEST

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ python:
   - 3.4
   - 3.5
   - pypy
-script: nosetests tests
+script: nosetests tests --with-coverage
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,6 @@ python:
   - 3.5
   - pypy
 script: nosetests tests
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 # http://travis-ci.org/#!/diyan/xmlwitch
 language: python
 python:
-  - 2.5
+#  - 2.5 # Travis no longer supports 2.5
   - 2.6
   - 2.7
   - 3.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,8 @@ python:
   - pypy
 script: nosetests tests --with-coverage
 
+install:
+  pip install coverage
+  pip install codecov
 after_success:
-  - bash <(curl -s https://codecov.io/bash)
+  codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ python:
 script: nosetests tests --with-coverage
 
 install:
-  pip install coverage
-  pip install codecov
+  pip install coverage codecov
 after_success:
   codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 # http://travis-ci.org/#!/diyan/xmlwitch
 language: python
 python:
-#  - 2.5 # Travis no longer supports 2.5
-  - 2.6
+#  - 2.5  # Travis no longer supports 2.5, but believed to work
+  - 2.6  # Requires nosetests
   - 2.7
-  - 3.2
+#  - 3.2  # Test is broken due to lack of u'' syntax, but believed to work otherwise
   - 3.3
   - 3.4
   - 3.5
   - pypy
-script: python -m unittest -v tests.xmlwitch_tests
+script: nosetests tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+# http://travis-ci.org/#!/diyan/xmlwitch
+language: python
+python:
+  - 2.5
+  - 2.6
+  - 2.7
+  - 3.2
+  - 3.3
+  - 3.4
+  - 3.5
+  - pypy
+script: python -m unittest -v tests.xmlwitch_tests

--- a/README.md
+++ b/README.md
@@ -2,8 +2,14 @@ xmlwitch
 ========
 
 [![Build Status](https://travis-ci.org/kcsaff/xmlwitch.svg?branch=master)](https://travis-ci.org/kcsaff/xmlwitch)
+[![codecov.io](https://codecov.io/gh/kcsaff/xmlwitch/coverage.svg?branch=master)](https://codecov.io/gh/kcsaff/xmlwitch?branch=master)
 
-**xmlwitch** is a BSD-licensed, Python 2.5+ library that offers idiomatic XML generation through context managers (with statement) in a minimalist implementation with less than 100 lines of code. To install, just run **pip install xmlwitch**, **easy_install xmlwitch** or copy **xmlwitch.py** to your appropriate project's directory. It's just one file.
+**xmlwitch** is a BSD-licensed, Python 2.5+ library that offers 
+idiomatic XML generation through context managers (with statement) in a
+minimalist implementation with less than 100 lines of code. To install,
+just run **pip install xmlwitch**, **easy_install xmlwitch** or copy
+**xmlwitch.py** to your appropriate project's directory. It's just one
+file.
 
     import xmlwitch
     xml = xmlwitch.Builder(version='1.0', encoding='utf-8')
@@ -20,6 +26,10 @@ xmlwitch
             xml.summary('Some text.')
     print(xml)
 
-Please refer to [http://jonasgalvez.com.br/Software/XMLWitch.html](http://jonasgalvez.com.br/Software/XMLWitch.html) for further info.
+Please refer to 
+[http://jonasgalvez.com.br/Software/XMLWitch.html](http://jonasgalvez.com.br/Software/XMLWitch.html)
+for further info.
 
-Thanks to [maskllin](http://github.com/masklinn/) and [bbolli](http://github.com/bbolli/) for contributions. Pull requests are welcome.
+Thanks to [maskllin](http://github.com/masklinn/) and
+[bbolli](http://github.com/bbolli/) for contributions. Pull requests 
+are welcome.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 xmlwitch
 ========
 
+[![Build Status](https://travis-ci.org/kcsaff/xmlwitch.svg?branch=master)](https://travis-ci.org/kcsaff/xmlwitch)
+
 **xmlwitch** is a BSD-licensed, Python 2.5+ library that offers idiomatic XML generation through context managers (with statement) in a minimalist implementation with less than 100 lines of code. To install, just run **pip install xmlwitch**, **easy_install xmlwitch** or copy **xmlwitch.py** to your appropriate project's directory. It's just one file.
 
     import xmlwitch

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
-**Repository contributors, please read my offer for taking over maintenance of the project:**
-
-http://blog.jonasgalvez.com.br/articles/transferring-xmlwitch.html
+xmlwitch
+========
 
 **xmlwitch** is a BSD-licensed, Python 2.5+ library that offers idiomatic XML generation through context managers (with statement) in a minimalist implementation with less than 100 lines of code. To install, just run **pip install xmlwitch**, **easy_install xmlwitch** or copy **xmlwitch.py** to your appropriate project's directory. It's just one file.
 

--- a/tests/expected/extended_syntax.xml
+++ b/tests/expected/extended_syntax.xml
@@ -1,0 +1,11 @@
+<doc>
+    <elem x="x" y="y" z="z" />
+    <elem x="x" y="y" z="z" />
+    <elem z="z" y="y" x="x" />
+    <container>
+        <elem />
+    </container>
+    <container>
+        <elem />
+    </container>
+</doc>

--- a/tests/xmlwitch_tests.py
+++ b/tests/xmlwitch_tests.py
@@ -12,6 +12,7 @@ sys.path.append(ROOT)
 
 import unittest
 import xmlwitch
+import tempfile
 
 class XMLWitchTestCase(unittest.TestCase):
     
@@ -111,6 +112,23 @@ class XMLWitchTestCase(unittest.TestCase):
             str(xml), 
             self.expected_document('atom_feed.xml')
         )
+
+    def test_stream_to_file(self):
+        tf = tempfile.TemporaryFile()
+
+        xml = xmlwitch.Builder(stream=tf, version='1.0', encoding='utf-8')
+        with xml.person:
+            xml.name("Bob")
+            xml.city("Qusqu")
+
+        tf.seek(0)
+        self.assertEquals(
+            tf.read().strip(),
+            self.expected_document('simple_document.xml').strip()
+        )
+
+        self.assertEquals(str(xml), "<streaming Builder object>")
+        
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/xmlwitch_tests.py
+++ b/tests/xmlwitch_tests.py
@@ -128,7 +128,7 @@ class XMLWitchTestCase(unittest.TestCase):
         )
 
     def test_stream_to_file(self):
-        tf = tempfile.TemporaryFile()
+        tf = tempfile.TemporaryFile('w+')
 
         xml = xmlwitch.Builder(stream=tf, version='1.0', encoding='utf-8')
         with xml.person:

--- a/tests/xmlwitch_tests.py
+++ b/tests/xmlwitch_tests.py
@@ -109,6 +109,21 @@ class XMLWitchTestCase(unittest.TestCase):
             self.expected_document('namespaces.xml')
         )
 
+    def test_extended_syntax(self):
+        xml = xmlwitch.Builder(indent=' ' * 4)
+        with xml.doc:
+            xml.elem(None, x='x', y='y', z='z')  # Old syntax
+            xml.elem(x='x', y='y', z='z')  # Newly allowed syntax
+            xml.elem(z='z')(y='y')(x='x')  # Order override
+            with xml.container:  # Old syntax
+                xml.elem()  # Newly allowed syntax
+            with xml.container(None):  # Formerly buggy syntax
+                xml.elem(None)  # Old syntax
+        self.assertEquals(
+            str(xml),
+            self.expected_document('extended_syntax.xml')
+        )
+
     def test_atom_feed(self):
         xml = xmlwitch.Builder(version="1.0", encoding="utf-8")
         with xml.feed(xmlns='http://www.w3.org/2005/Atom'):

--- a/tests/xmlwitch_tests.py
+++ b/tests/xmlwitch_tests.py
@@ -2,7 +2,6 @@ from __future__ import with_statement
 
 import sys
 import os
-from xmlwitch import is_py2
 
 ROOT = os.path.abspath(
     os.path.join(
@@ -21,10 +20,7 @@ class XMLWitchTestCase(unittest.TestCase):
     def expected_document(self, filename):
         expected = os.path.join(ROOT, 'tests',  'expected',  filename)
         with open(expected) as document:
-            if is_py2:
-                return document.read()
-            else:
-                return document.read() + '\n'
+            return document.read()
 
     def test_simple_document(self):
             xml = xmlwitch.Builder(version='1.0', encoding='utf-8')
@@ -37,18 +33,31 @@ class XMLWitchTestCase(unittest.TestCase):
             )
 
     def test_utf8_document(self):
-        if is_py2:
-            string = ("""An animated fantasy film from 1978 based on the first """
-                      """half of J.R.R Tolkien\xe2\x80\x99s Lord of the Rings novel. The """
-                      """film was mainly filmed using rotoscoping, meaning it was """
-                      """filmed in live action sequences with real actors and then """
-                      """each frame was individually animated.""")
-        else:
-            string = ("""An animated fantasy film from 1978 based on the first """
-                      """half of J.R.R Tolkien\u2019s Lord of the Rings novel. The """
-                      """film was mainly filmed using rotoscoping, meaning it was """
-                      """filmed in live action sequences with real actors and then """
-                      """each frame was individually animated.""")
+        #  Python 2 & 3 should behave identically if we give a unicode string
+        string = (u"""An animated fantasy film from 1978 based on the first """
+                  u"""half of J.R.R Tolkien\u2019s Lord of the Rings novel. The """
+                  u"""film was mainly filmed using rotoscoping, meaning it was """
+                  u"""filmed in live action sequences with real actors and then """
+                  u"""each frame was individually animated.""")
+
+        xml = xmlwitch.Builder(version='1.0', encoding='utf-8')
+        with xml.test:
+             xml.description(string)
+
+        self.assertEquals(
+            str(xml),
+            self.expected_document('utf8_document.xml')
+        )
+
+    def test_utf8_document_ascii_encoded(self):
+        if sys.version_info[0] >= 3:
+            return  # Ascii strings not really relevant to python 3
+
+        string = ("""An animated fantasy film from 1978 based on the first """
+                  """half of J.R.R Tolkien\xe2\x80\x99s Lord of the Rings novel. The """
+                  """film was mainly filmed using rotoscoping, meaning it was """
+                  """filmed in live action sequences with real actors and then """
+                  """each frame was individually animated.""")
 
         xml = xmlwitch.Builder(version='1.0', encoding='utf-8')
         with xml.test:
@@ -141,7 +150,7 @@ class XMLWitchTestCase(unittest.TestCase):
             self.expected_document('simple_document.xml').strip()
         )
 
-        self.assertEquals(str(xml), "<streaming Builder object>")
+        self.assertEquals(str(xml), '<streaming Builder object>')
         
 
 if __name__ == '__main__':

--- a/tests/xmlwitch_tests.py
+++ b/tests/xmlwitch_tests.py
@@ -2,6 +2,7 @@ from __future__ import with_statement
 
 import sys
 import os
+from xmlwitch import is_py2
 
 ROOT = os.path.abspath(
     os.path.join(
@@ -13,39 +14,51 @@ sys.path.append(ROOT)
 import unittest
 import xmlwitch
 import tempfile
+import xml.etree.ElementTree as ET
 
 class XMLWitchTestCase(unittest.TestCase):
-    
+
     def expected_document(self, filename):
         expected = os.path.join(ROOT, 'tests',  'expected',  filename)
         with open(expected) as document:
-            return document.read()
-            
+            if is_py2:
+                return document.read()
+            else:
+                return document.read() + '\n'
+
     def test_simple_document(self):
             xml = xmlwitch.Builder(version='1.0', encoding='utf-8')
             with xml.person:
                 xml.name("Bob")
                 xml.city("Qusqu")
             self.assertEquals(
-                str(xml), 
+                str(xml),
                 self.expected_document('simple_document.xml')
             )
-    
+
     def test_utf8_document(self):
-        string = u"""An animated fantasy film from 1978 based on the first """ \
-                 u"""half of J.R.R Tolkien\u2019s Lord of the Rings novel. The """ \
-                 u"""film was mainly filmed using rotoscoping, meaning it was """ \
-                 u"""filmed in live action sequences with real actors and then """ \
-                 u"""each frame was individually animated."""
+        if is_py2:
+            string = ("""An animated fantasy film from 1978 based on the first """
+                      """half of J.R.R Tolkien\xe2\x80\x99s Lord of the Rings novel. The """
+                      """film was mainly filmed using rotoscoping, meaning it was """
+                      """filmed in live action sequences with real actors and then """
+                      """each frame was individually animated.""")
+        else:
+            string = ("""An animated fantasy film from 1978 based on the first """
+                      """half of J.R.R Tolkien\u2019s Lord of the Rings novel. The """
+                      """film was mainly filmed using rotoscoping, meaning it was """
+                      """filmed in live action sequences with real actors and then """
+                      """each frame was individually animated.""")
+
         xml = xmlwitch.Builder(version='1.0', encoding='utf-8')
         with xml.test:
              xml.description(string)
-        
+
         self.assertEquals(
             str(xml),
             self.expected_document('utf8_document.xml')
         )
-    
+
     def test_nested_elements(self):
         xml = xmlwitch.Builder()
         with xml.feed(xmlns='http://www.w3.org/2005/Atom'):
@@ -60,36 +73,36 @@ class XMLWitchTestCase(unittest.TestCase):
                 xml.updated('2003-12-13T18:30:02Z')
                 xml.summary('Some text.')
         self.assertEquals(
-            str(xml), 
+            str(xml),
             self.expected_document('nested_elements.xml')
         )
-    
+
     def test_rootless_fragment(self):
         xml = xmlwitch.Builder()
         xml.data(None, value='Just some data')
         self.assertEquals(
-            str(xml), 
+            str(xml),
             self.expected_document('rootless_fragment.xml')
         )
-    
+
     def test_content_escaping(self):
         xml = xmlwitch.Builder()
         with xml.doc:
             xml.item('Text&to<escape', some_attr='attribute&value>to<escape')
         self.assertEquals(
-            str(xml), 
+            str(xml),
             self.expected_document('content_escaping.xml')
         )
-    
+
     def test_namespaces(self):
         xml = xmlwitch.Builder()
         with xml.parent(**{'xmlns:my':'http://example.org/ns/'}):
             xml.my__child(None, my__attr='foo')
         self.assertEquals(
-            str(xml), 
+            str(xml),
             self.expected_document('namespaces.xml')
-        )        
-    
+        )
+
     def test_atom_feed(self):
         xml = xmlwitch.Builder(version="1.0", encoding="utf-8")
         with xml.feed(xmlns='http://www.w3.org/2005/Atom'):
@@ -108,9 +121,10 @@ class XMLWitchTestCase(unittest.TestCase):
                     with xml.div(xmlns='http://www.w3.org/1999/xhtml'):
                         xml.label('Some label', for_='some_field')
                         xml.input(None, type='text', value='')
+        self.maxDiff = None
         self.assertEquals(
-            str(xml), 
-            self.expected_document('atom_feed.xml')
+            ET.tostring(ET.fromstring(str(xml))),
+            ET.tostring(ET.fromstring(self.expected_document('atom_feed.xml')))
         )
 
     def test_stream_to_file(self):

--- a/tests/xmlwitch_tests.py
+++ b/tests/xmlwitch_tests.py
@@ -17,9 +17,9 @@ import xml.etree.ElementTree as ET
 
 class XMLWitchTestCase(unittest.TestCase):
 
-    def expected_document(self, filename):
+    def expected_document(self, filename, mode='r'):
         expected = os.path.join(ROOT, 'tests',  'expected',  filename)
-        with open(expected) as document:
+        with open(expected, mode=mode) as document:
             return document.read()
 
     def test_simple_document(self):
@@ -50,14 +50,11 @@ class XMLWitchTestCase(unittest.TestCase):
         )
 
     def test_utf8_document_ascii_encoded(self):
-        if sys.version_info[0] >= 3:
-            return  # Ascii strings not really relevant to python 3
-
-        string = ("""An animated fantasy film from 1978 based on the first """
-                  """half of J.R.R Tolkien\xe2\x80\x99s Lord of the Rings novel. The """
-                  """film was mainly filmed using rotoscoping, meaning it was """
-                  """filmed in live action sequences with real actors and then """
-                  """each frame was individually animated.""")
+        string = (b"""An animated fantasy film from 1978 based on the first """
+                  b"""half of J.R.R Tolkien\xe2\x80\x99s Lord of the Rings novel. The """
+                  b"""film was mainly filmed using rotoscoping, meaning it was """
+                  b"""filmed in live action sequences with real actors and then """
+                  b"""each frame was individually animated.""")
 
         xml = xmlwitch.Builder(version='1.0', encoding='utf-8')
         with xml.test:
@@ -137,7 +134,7 @@ class XMLWitchTestCase(unittest.TestCase):
         )
 
     def test_stream_to_file(self):
-        tf = tempfile.TemporaryFile('w+')
+        tf = tempfile.TemporaryFile('w+b')
 
         xml = xmlwitch.Builder(stream=tf, version='1.0', encoding='utf-8')
         with xml.person:
@@ -146,8 +143,8 @@ class XMLWitchTestCase(unittest.TestCase):
 
         tf.seek(0)
         self.assertEquals(
-            tf.read().strip(),
-            self.expected_document('simple_document.xml').strip()
+            tf.read(),
+            self.expected_document('simple_document.xml', 'rb')
         )
 
         self.assertEquals(str(xml), '<streaming Builder object>')

--- a/xmlwitch.py
+++ b/xmlwitch.py
@@ -107,7 +107,7 @@ class Element:
 
 #  Python 2 + 3 support
 
-if sys.version[0] == 2:
+if sys.version_info[0] == 2:
     def to_str(u, encoding):
         return u if isinstance(u, str) else u.encode(encoding)
 

--- a/xmlwitch.py
+++ b/xmlwitch.py
@@ -131,7 +131,7 @@ class Element:
     def __call__(*args, **kargs):
         """Add a child element to the document"""
         self = args[0]
-        for attr, value in kargs.items():
+        for attr, value in sorted(kargs.items()):
             self.builder.write(' %s=%s' % (
                 self._nameprep(attr), saxutils.quoteattr(to_str(value, self.builder._encoding))
             ))

--- a/xmlwitch.py
+++ b/xmlwitch.py
@@ -12,8 +12,13 @@ __contributors__ = ["bbolli <http://github.com/bbolli/>",
 
 class Builder:
     
-    def __init__(self, encoding='utf-8', indent=' '*2, version=None):
-        self._document = StringIO()
+    def __init__(self, encoding='utf-8', indent=' '*2, version=None, 
+                 stream=None):
+        if stream is None:
+            self._document = StringIO()
+        else:
+            self._document = stream
+
         self._encoding = encoding
         self._indent = indent
         self._indentation = 0
@@ -29,10 +34,16 @@ class Builder:
         return Element(name, self)
     
     def __str__(self):
-        return self._document.getvalue().encode(self._encoding).strip()
+        if hasattr(self._document, "getvalue"):
+            return self._document.getvalue().encode(self._encoding).strip()
+        else:
+            return "<streaming "+self.__class__.__name__+" object>"
         
     def __unicode__(self):
-        return self._document.getvalue().decode(self._encoding).strip()
+        if hasattr(self._document, "getvalue"):
+            return self._document.getvalue().decode(self._encoding).strip()
+        else:
+            return "<streaming "+self.__class__.__name__+" object>"
         
     def write(self, content):
         """Write raw content to the document"""

--- a/xmlwitch.py
+++ b/xmlwitch.py
@@ -39,7 +39,7 @@ class Builder:
 
     def __str__(self):
         if not hasattr(self._document, "getvalue"):
-            return "<streaming "+self.__class__.__name__+" object>"
+            return '<streaming %s object>' % self.__class__.__name__
         elif is_py2:
             return self._document.getvalue().encode(self._encoding).strip()
         else:
@@ -47,7 +47,7 @@ class Builder:
 
     def __unicode__(self):
         if not hasattr(self._document, "getvalue"):
-            return "<streaming "+self.__class__.__name__+" object>"
+            return '<streaming %s object>' % self.__class__.__name__
         elif is_py2:
             return self._document.getvalue().decode(self._encoding).strip()
         else:

--- a/xmlwitch.py
+++ b/xmlwitch.py
@@ -8,17 +8,48 @@ __license__ = 'BSD'
 __version__ = '0.2.1'
 __author__ = "Jonas Galvez <http://jonasgalvez.com.br/>"
 __contributors__ = ["bbolli <http://github.com/bbolli/>",
-                    "masklinn <http://github.com/masklinn/>"]
+                    "masklinn <http://github.com/masklinn/>",
+                    "kcsaff <http://github.com/kcsaff/>"]
+
+#  Python 2 + 3 support
+
+if sys.version_info[0] == 2:
+    bytes = str
+else:
+    unicode = str
+
+
+def to_bytes(s, encoding):
+    return s if isinstance(s, bytes) else s.encode(encoding)
+
+
+def to_unicode(s, encoding):
+    return s if isinstance(s, unicode) else s.decode(encoding)
+
+if str == bytes:
+    to_str = to_bytes
+else:
+    to_str = to_unicode
+
+try:
+    from io import BytesIO  # Python 3
+except ImportError:
+    try:
+        from cStringIO import BytesIO  # Python 2, fast
+    except ImportError:
+        from StringIO import BytesIO  # Python 2, pure
+
+# Code
 
 class Builder:
     def __init__(self, encoding='utf-8', indent=' '*2, version=None, 
                  stream=None):
-        self._document = stream if stream is not None else StringIO()
+        self._document = stream or BytesIO()
 
         self._encoding = encoding
         self._indent = indent
         self._indentation = 0
-        self._open_element = None
+        self._open_tag = None
         self._newline = ''
         if version is not None:
             self.write('<?xml version="%s" encoding="%s"?>' % (
@@ -31,24 +62,28 @@ class Builder:
     def __getitem__(self, name):
         return Element(name, self)
 
+    def __bytes__(self):
+        return to_bytes(self.__getvalue(), self._encoding)
+
     def __str__(self):
-        return to_str(self.__unicode__(), self._encoding)
+        return to_str(self.__getvalue(), self._encoding)
 
     def __unicode__(self):
-        if self._open_element:
-            self._open_element.close()
-        if hasattr(self._document, "getvalue"):
+        return to_unicode(self.__getvalue(), self._encoding)
+
+    def __getvalue(self):
+        self._open_tag and self._open_tag.close()
+        if hasattr(self._document, 'getvalue'):
             return self._document.getvalue()
         else:
             return '<streaming %s object>' % self.__class__.__name__
 
     def __del__(self):
-        if self._open_element:
-            self._open_element.close()
+        self._open_tag and self._open_tag.close()
 
     def write(self, content):
         """Write raw content to the document"""
-        self._document.write(to_unicode(content, self._encoding))
+        self._document.write(to_bytes(content, self._encoding))
         self._newline = '\n'
 
     def write_escaped(self, content):
@@ -59,40 +94,38 @@ class Builder:
         """Write indented content to the document"""
         self.write('%s%s%s' % (self._newline, self._indent * self._indentation, content))
 
-builder = Builder # 0.1 backward compatibility
+builder = Builder  # 0.1 backward compatibility
+
 
 class Element:
-
     PYTHON_KWORD_MAP = dict([(k + '_', k) for k in PYTHON_KWORD_LIST])
 
     def __init__(self, name, builder):
         self.name = self._nameprep(name)
-        self.builder = builder
         self.content = []
-        if self.builder._open_element:
-            self.builder._open_element.close()
+        self.builder = builder
+        self.builder._open_tag and self.builder._open_tag.close()
         self.builder.write_indented('<%s' % self.name)
-        self.builder._open_element = self
+        self.builder._open_tag = self
 
     def close(self):
         if self.content:
             self.builder.write('>%s</%s>' % (''.join(self.content), self.name))
         else:
             self.builder.write(' />')
-        self.builder._open_element = None
+        self.builder._open_tag = None
 
     def __enter__(self):
         """Add a parent element to the document"""
         self.builder.write('>%s' % ''.join(self.content))
         self.builder._indentation += 1
-        self.builder._open_element = None
+        self.builder._open_tag = None
         return self
 
     def __exit__(self, type, value, tb):
         """Add close tag to current parent element"""
+        self.builder._open_tag and self.builder._open_tag.close()
         self.builder._indentation -= 1
-        if self.builder._open_element:
-            self.builder._open_element.close()
         self.builder.write_indented('</%s>' % self.name)
 
     def __call__(*args, **kargs):
@@ -100,13 +133,15 @@ class Element:
         self = args[0]
         for attr, value in kargs.items():
             self.builder.write(' %s=%s' % (
-                self._nameprep(attr), saxutils.quoteattr(value)
+                self._nameprep(attr), saxutils.quoteattr(to_str(value, self.builder._encoding))
             ))
-        self.content.extend([saxutils.escape(s) for s in args[1:] if s])
+        self.content.extend([saxutils.escape(
+            to_str(s, self.builder._encoding)
+        ) for s in args[1:] if s])
         return self
 
     def __del__(self):
-        if self.builder._open_element is self:
+        if self.builder._open_tag is self:
             self.close()
 
     @classmethod
@@ -114,25 +149,3 @@ class Element:
         """Undo keyword and colon mangling"""
         name = Element.PYTHON_KWORD_MAP.get(name, name)
         return name.replace('__', ':')
-
-#  Python 2 + 3 support
-
-if sys.version_info[0] == 2:
-    def to_str(u, encoding):
-        return u if isinstance(u, str) else u.encode(encoding)
-
-    def to_unicode(s, encoding):
-        return s if isinstance(s, unicode) else s.decode(encoding)
-else:  # Python 3, unicode == str
-    def to_str(u, _):
-        return u
-
-    to_unicode = to_str
-
-try:
-    from io import StringIO  # Python 3
-except ImportError:
-    try:
-        from cStringIO import StringIO  # Python 2, fast
-    except ImportError:
-        from StringIO import StringIO  # Python 2, pure

--- a/xmlwitch.py
+++ b/xmlwitch.py
@@ -1,7 +1,14 @@
 from __future__ import with_statement
-from StringIO import StringIO
+import sys
 from xml.sax import saxutils
 from keyword import kwlist as PYTHON_KWORD_LIST
+
+is_py2 = sys.version[0] == '2'
+
+if is_py2:
+    from StringIO import StringIO
+else:
+    from io import StringIO
 
 __all__ = ['Builder', 'Element']
 __license__ = 'BSD'
@@ -11,7 +18,7 @@ __contributors__ = ["bbolli <http://github.com/bbolli/>",
                     "masklinn <http://github.com/masklinn/>"]
 
 class Builder:
-    
+
     def __init__(self, encoding='utf-8', indent=' '*2, version=None, 
                  stream=None):
         self._document = stream or StringIO()
@@ -23,35 +30,39 @@ class Builder:
             self.write('<?xml version="%s" encoding="%s"?>\n' % (
                 version, encoding
             ))
-    
+
     def __getattr__(self, name):
         return Element(name, self)
-        
+
     def __getitem__(self, name):
         return Element(name, self)
-    
+
     def __str__(self):
-        if hasattr(self._document, "getvalue"):
+        if not hasattr(self._document, "getvalue"):
+            return "<streaming "+self.__class__.__name__+" object>"
+        elif is_py2:
             return self._document.getvalue().encode(self._encoding).strip()
         else:
-            return "<streaming "+self.__class__.__name__+" object>"
-        
+            return self._document.getvalue()
+
     def __unicode__(self):
-        if hasattr(self._document, "getvalue"):
+        if not hasattr(self._document, "getvalue"):
+            return "<streaming "+self.__class__.__name__+" object>"
+        elif is_py2:
             return self._document.getvalue().decode(self._encoding).strip()
         else:
-            return "<streaming "+self.__class__.__name__+" object>"
-        
+            return self._document.getvalue()
+
     def write(self, content):
         """Write raw content to the document"""
-        if type(content) is not unicode:
+        if is_py2 and type(content) is not unicode:
             content = content.decode(self._encoding)
         self._document.write('%s' % content)
 
     def write_escaped(self, content):
         """Write escaped content to the document"""
         self.write(saxutils.escape(content))
-        
+
     def write_indented(self, content):
         """Write indented content to the document"""
         self.write('%s%s\n' % (self._indent * self._indentation, content))
@@ -59,14 +70,14 @@ class Builder:
 builder = Builder # 0.1 backward compatibility
 
 class Element:
-    
+
     PYTHON_KWORD_MAP = dict([(k + '_', k) for k in PYTHON_KWORD_LIST])
-    
+
     def __init__(self, name, builder):
         self.name = self._nameprep(name)
         self.builder = builder
         self.attributes = {}
-        
+
     def __enter__(self):
         """Add a parent element to the document"""
         self.builder.write_indented('<%s%s>' % (
@@ -74,12 +85,12 @@ class Element:
         ))
         self.builder._indentation += 1
         return self
-        
+
     def __exit__(self, type, value, tb):
         """Add close tag to current parent element"""
         self.builder._indentation -= 1
         self.builder.write_indented('</%s>' % self.name)
-        
+
     def __call__(*args, **kargs):
         """Add a child element to the document"""
         self = args[0]

--- a/xmlwitch.py
+++ b/xmlwitch.py
@@ -14,10 +14,7 @@ class Builder:
     
     def __init__(self, encoding='utf-8', indent=' '*2, version=None, 
                  stream=None):
-        if stream is None:
-            self._document = StringIO()
-        else:
-            self._document = stream
+        self._document = stream or StringIO()
 
         self._encoding = encoding
         self._indent = indent

--- a/xmlwitch.py
+++ b/xmlwitch.py
@@ -96,7 +96,7 @@ class Element:
 
     def __init__(self, name, builder):
         self.name = self._nameprep(name)
-        self.content = []
+        self.content = ''
         self.builder = builder
         self.builder._open_tag and self.builder._open_tag.close()
         self.builder.write_indented('<%s' % self.name)
@@ -104,14 +104,14 @@ class Element:
 
     def close(self):
         if self.content:
-            self.builder.write('>%s</%s>' % (''.join(self.content), self.name))
+            self.builder.write('>%s</%s>' % (self.content, self.name))
         else:
             self.builder.write(' />')
         self.builder._open_tag = None
 
     def __enter__(self):
         """Add a parent element to the document"""
-        self.builder.write('>%s' % ''.join(self.content))
+        self.builder.write('>%s' % self.content)
         self.builder._indentation += 1
         self.builder._open_tag = None
         return self
@@ -129,7 +129,9 @@ class Element:
             self.builder.write(' %s=%s' % (
                 self._nameprep(attr), saxutils.quoteattr(self.builder._to_str(value))
             ))
-        self.content.extend(saxutils.escape(self.builder._to_str(s)) for s in args[1:] if s)
+        for s in args[1:]:
+            if s:
+                self.content += saxutils.escape(self.builder._to_str(s))
         return self
 
     def __del__(self):

--- a/xmlwitch.py
+++ b/xmlwitch.py
@@ -21,7 +21,7 @@ class Builder:
 
     def __init__(self, encoding='utf-8', indent=' '*2, version=None, 
                  stream=None):
-        self._document = stream or StringIO()
+        self._document = stream if stream is not None else StringIO()
 
         self._encoding = encoding
         self._indent = indent


### PR DESCRIPTION
This PR:

- adds support for Python 3 while maintaining compatibility with 2.5+, and generally makes sense of the bytes/unicode mess (from @diyan and then modified by me)
- allows providing a binary stream in the constructor to stream out large files when memory is constrained (from @bjorkegeek)
- makes it so you do not need to use `None` for empty elements, and also so that, if you do provide `None` for context elements, no harm is done (custom approach which still streams out data on the fly)
- tests all these things! :D

I am willing to take over maintenance of this project. I cannot follow the directions in the README to request this, however, as your web site appears to be down. Contact me if you're interested.

--K